### PR TITLE
fixes #37 - calculate col start if ommitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ internals.parse = function (specs, input) {
 	if (lodash.isEmpty(specs.map)) throw new Error('specs maps is empty')
 	if (lodash.isEmpty(specs.options)) throw new Error('specs options is empty')
 	if (input === '') throw new Error('input is empty')
+	specs = startCheck(specs)
 	var arrayOutput = []
 	var objectOutput = {}
 	var splitInput = input.replace(/\r\n/g, '\n').split('\n')
@@ -224,6 +225,15 @@ internals.unparse = function (specs, input, levels) {
 
 const preprocessCheck = (spec, value) => {
 	return (spec.preprocess) ? spec.preprocess(value) : value
+}
+
+const startCheck = (specs) => {
+	let nextStart = 1
+	specs.map.forEach(col => {
+		if (!col.start) col.start = nextStart
+		nextStart = col.start + col.width
+	})
+	return specs
 }
 
 module.exports = internals

--- a/index.js
+++ b/index.js
@@ -229,9 +229,10 @@ const preprocessCheck = (spec, value) => {
 
 const startCheck = (specs) => {
 	let nextStart = 1
-	specs.map.forEach(col => {
+	specs.map = specs.map.map(col => {
 		if (!col.start) col.start = nextStart
 		nextStart = col.start + col.width
+		return col
 	})
 	return specs
 }

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,28 @@ describe('Fixy Tests', function () {
 			}])
 		})
 
+		it('should calculate map[x].start when it is omitted', function () {
+			var test = fixy.parse({
+				map: [{
+					name: 'Age',
+					width: 2,
+					type: 'int'
+				}, {
+					name: 'Name',
+					width: 4,
+					type: 'string'
+				}],
+				options: {
+					fullwidth: 6
+				}
+			}, '30john')
+
+			assert.deepStrictEqual(test, [{
+				Age: 30,
+				Name: 'john'
+			}])
+		})
+
 		it('should return fixed-width-input as array(object)', function () {
 			var test = fixy.parse({
 				map: [{


### PR DESCRIPTION
Created function `startCheck`, which does the following:

traverses each element of spec.map and, if start is missing, calculates it from previous column start + previous column width.

WARNING: startCheck modifies the content of specs (and ultimately the specs passed to fixy.parse)

To avoid it we could make a deep copy (I think `JSON.parse(JSON.stringify(specs))` should be ok in this case, otherwise we may use lodash.cloneDeep)

I don't know if it's worth the effort, I think returning the spec with calculated start is not bad.

Also added a simple test (should calculate map[x].start when it is omitted)