### PR TITLE
Fix: truncate too long values of multi level unparse too

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,8 +175,8 @@ internals.unparse = function (specs, input, levels) {
 									break
 							}
 						}
-						output = output + value.substring(0, spec.width)
 					}
+					output = output + value.substring(0, spec.width)
 				})
 				counter = counter + 1
 				if (rowCount !== counter) {


### PR DESCRIPTION
Instead of dropping them